### PR TITLE
Adjusted CSS to center multiple divs on the page

### DIFF
--- a/src/Pages/ProgressPage/ProgressPage.jsx
+++ b/src/Pages/ProgressPage/ProgressPage.jsx
@@ -31,7 +31,7 @@ const ProgressPage = ({ consistencyPoints, currentStreak, avgProblems, sheets })
 
   return (
     <div className="max-w-5xl m-auto">
-      <div className="flex gap-4 justify-between flex-wrap sm:items-center">
+      <div className="flex gap-4 flex-wrap justify-center md:justify-between sm:items-center">
         
         {/* ConsistencyTracker component displays the user's current streak and consistency points */}
         <div>


### PR DESCRIPTION
This pull request centers multiple `div` elements on the webpage to improve the overall layout and visual alignment.
![updatedImage](https://github.com/user-attachments/assets/427390f6-d579-41af-bebc-81da2adab91a)
